### PR TITLE
GitHub Pages Simple

### DIFF
--- a/GitHubPages-Simple.md
+++ b/GitHubPages-Simple.md
@@ -1,0 +1,56 @@
+# Introducción
+
+Usa [GitHub Pages][1] y el gestor de temas [Jekyll][2] para crear un sitio web de páginas estáticas que todo mundo pueda ver de forma muy sencilla.
+
+# Instrucciones
+
+## Crea un repositorio / sitio web en GitHub Pages
+
+1. Si aún no la tienes, crea una cuenta en [GitHub][3].
+2. Crea un nuevo repositorio usando `nombredeusario.github.io` como nombre del mismo.
+3. Haz clic en "Settings".
+4. En la sección de GitHub pages haz clic en "Choose a theme".
+5. Revisa los temas y escoge uno.
+6. Te dará la opción de editar el archivo README.md. Si lo deseas, cancela para editarlo posteriormente.
+
+## Crea una nueva página para probar tu código html
+
+1. Ve al repositorio en GitHub.  
+1. Agrega una página.  
+1. Agrega el nombre de archivo con extensión .html  
+1. Agrega tu código y guárdalo.
+1. Ve al enlace de la página, `nombredeusario.github.io/mipagina.html` y revisa el resultado.  
+
+### Ejemplo parcial
+
+#### Repositorio  
+
+https://github.com/rubenrivera/rubenrivera.github.io/
+
+#### Fuente HTML ¡Hola mundo!
+
+    <html>
+      <body>
+        ¡Hola mundo!
+      </body>
+    </html>
+
+#### Enlace al archivo en GitHub
+
+https://github.com/rubenrivera/rubenrivera.github.io/blob/master/holamundo.html
+
+#### Enlace a la página publicada  
+
+Un enlace como este sería el que utilizarías para evaluar tu página en la herramienta para desarrolladores de Facebook o cualquier otro similar
+
+https://rubenrivera.github.io/holamundo.html
+
+# Referencias
+
+[Creating a GitHub Pages site with the Jekyll Theme Chooser][4]
+
+
+  [1]: https://pages.github.com/
+  [2]: https://jekyllrb.com/
+  [3]: http://github.com
+  [4]: https://help.github.com/articles/creating-a-github-pages-site-with-the-jekyll-theme-chooser/

--- a/GitHubPages-Simple.md
+++ b/GitHubPages-Simple.md
@@ -1,19 +1,21 @@
-# Introducción
+# GitHub Pages Simple
+
+## Introducción
 
 Usa [GitHub Pages][1] y el gestor de temas [Jekyll][2] para crear un sitio web de páginas estáticas que todo mundo pueda ver de forma muy sencilla.
 
-# Instrucciones
+## Instrucciones
 
-## Crea un repositorio / sitio web en GitHub Pages
+### Crea un repositorio / sitio web en GitHub Pages
 
 1. Si aún no la tienes, crea una cuenta en [GitHub][3].
 2. Crea un nuevo repositorio usando `nombredeusario.github.io` como nombre del mismo.
 3. Haz clic en "Settings".
-4. En la sección de GitHub pages haz clic en "Choose a theme".
+4. En la sección de GitHub Pages haz clic en "Choose a theme".
 5. Revisa los temas y escoge uno.
 6. Te dará la opción de editar el archivo README.md. Si lo deseas, cancela para editarlo posteriormente.
 
-## Crea una nueva página para probar tu código html
+### Crea una nueva página para probar tu código html
 
 1. Ve al repositorio en GitHub.  
 1. Agrega una página.  
@@ -21,13 +23,13 @@ Usa [GitHub Pages][1] y el gestor de temas [Jekyll][2] para crear un sitio web d
 1. Agrega tu código y guárdalo.
 1. Ve al enlace de la página, `nombredeusario.github.io/mipagina.html` y revisa el resultado.  
 
-### Ejemplo parcial
+#### Ejemplo parcial
 
-#### Repositorio  
+##### Repositorio  
 
 https://github.com/rubenrivera/rubenrivera.github.io/
 
-#### Fuente HTML ¡Hola mundo!
+##### Fuente HTML ¡Hola mundo!
 
     <html>
       <body>
@@ -35,11 +37,11 @@ https://github.com/rubenrivera/rubenrivera.github.io/
       </body>
     </html>
 
-#### Enlace al archivo en GitHub
+##### Enlace al archivo en GitHub
 
 https://github.com/rubenrivera/rubenrivera.github.io/blob/master/holamundo.html
 
-#### Enlace a la página publicada  
+##### Enlace a la página publicada  
 
 Un enlace como este sería el que utilizarías para evaluar tu página en la herramienta para desarrolladores de Facebook o cualquier otro similar
 

--- a/GitHubPages-Simple.md
+++ b/GitHubPages-Simple.md
@@ -2,13 +2,13 @@
 
 ## Introducción
 
-Usa [GitHub Pages][1] y el gestor de temas [Jekyll][2] para crear un sitio web de páginas estáticas que todo mundo pueda ver de forma muy sencilla.
+Usa [GitHub Pages][1] y el gestor de temas [Jekyll][2] para crear un sitio web de páginas estáticas que todo mundo pueda ver de forma muy sencilla. Los pasos indicados en esta guía se llevan a cabo complementamente usando un navegador web, sin necesidad de comandos de línea. Para conocer más sobre GitHub ve a [GitHub Simple][3].
 
 ## Instrucciones
 
 ### Crea un repositorio / sitio web en GitHub Pages
 
-1. Si aún no la tienes, crea una cuenta en [GitHub][3].
+1. Si aún no la tienes, crea una cuenta en [GitHub][4].
 2. Crea un nuevo repositorio usando `nombredeusario.github.io` como nombre del mismo.
 3. Haz clic en "Settings".
 4. En la sección de GitHub Pages haz clic en "Choose a theme".
@@ -23,7 +23,7 @@ Usa [GitHub Pages][1] y el gestor de temas [Jekyll][2] para crear un sitio web d
 1. Agrega tu código y guárdalo.
 1. Ve al enlace de la página, `nombredeusario.github.io/mipagina.html` y revisa el resultado.  
 
-#### Ejemplo parcial
+#### Ejemplo simple
 
 ##### Repositorio  
 
@@ -49,10 +49,11 @@ https://rubenrivera.github.io/holamundo.html
 
 # Referencias
 
-[Creating a GitHub Pages site with the Jekyll Theme Chooser][4]
+[Creating a GitHub Pages site with the Jekyll Theme Chooser][5]
 
 
   [1]: https://pages.github.com/
   [2]: https://jekyllrb.com/
-  [3]: http://github.com
-  [4]: https://help.github.com/articles/creating-a-github-pages-site-with-the-jekyll-theme-chooser/
+  [3]: /README.md
+  [4]: http://github.com
+  [5]: https://help.github.com/articles/creating-a-github-pages-site-with-the-jekyll-theme-chooser/


### PR DESCRIPTION
Agregar GitHubPages-Simple.md el cual es un archivo con instrucciones sobre cómo crear un repositorio para ser usado como sitio web de páginas estáticas de forma muy simple para que aquellas personas que quieren compartir o probar una página web de forma sencilla.